### PR TITLE
Update development dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,23 +2,29 @@
 AllCops:
   TargetRubyVersion: 2.3
 
+Layout/AlignArguments:
+  EnforcedStyle: with_fixed_indentation
+
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
-Layout/IndentArray:
+Layout/IndentFirstArgument:
   EnforcedStyle: consistent
 
-Layout/IndentHash:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
-Style/Documentation:
-  Enabled: false
+Layout/IndentFirstHashElement:
+  EnforcedStyle: consistent
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
+
+Style/Documentation:
+  Enabled: false
 
 Style/FrozenStringLiteralComment:
   Enabled: true

--- a/epilog.gemspec
+++ b/epilog.gemspec
@@ -19,16 +19,17 @@ Gem::Specification.new do |spec|
     .reject { |f| f.match(%r{^spec/}) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.12'
-  spec.add_development_dependency 'byebug', '~> 9.0'
-  spec.add_development_dependency 'combustion', '~> 1.0.0'
+  spec.add_development_dependency 'bundler', '>= 1.12'
+  spec.add_development_dependency 'byebug', '~> 11.0'
+  spec.add_development_dependency 'combustion', '~> 1.1.0'
+  spec.add_development_dependency 'irb'
   spec.add_development_dependency 'rails', '>= 4.2', '< 6'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'redcarpet', '~> 3.4'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'redcarpet', '~> 3.5'
   spec.add_development_dependency 'rspec', '~> 3.4'
   spec.add_development_dependency 'rspec-rails', '~> 3.8.1'
-  spec.add_development_dependency 'rubocop', '~> 0.61'
-  spec.add_development_dependency 'simplecov', '~> 0.12'
-  spec.add_development_dependency 'sqlite3', '~> 1.3'
+  spec.add_development_dependency 'rubocop', '0.75'
+  spec.add_development_dependency 'simplecov', '~> 0.17'
+  spec.add_development_dependency 'sqlite3', '~> 1.3', '< 1.4'
   spec.add_development_dependency 'yard', '~> 0.9.11'
 end


### PR DESCRIPTION
Some development dependencies were out of date, simply bump the required
versions to the latest with some exceptions:

- Allow bundler 1 and 2
- sqlite3 must be < 1.4 for Rails 4 support
- Add irb for Ruby 2.6 support