### PR TITLE
Allow controllers to add context to logs

### DIFF
--- a/lib/epilog/rails/action_controller_subscriber.rb
+++ b/lib/epilog/rails/action_controller_subscriber.rb
@@ -17,13 +17,13 @@ module Epilog
 
       def process_request(event)
         info do
-          {
+          event.payload[:context].merge(
             message: response_string(event),
             request: short_request_hash(event),
             response: response_hash(event),
             metrics: process_metrics(event.payload[:metrics]
               .merge(request_runtime: event.duration.round(2)))
-          }
+          )
         end
       end
 

--- a/lib/epilog/rails/ext/action_controller.rb
+++ b/lib/epilog/rails/ext/action_controller.rb
@@ -10,6 +10,7 @@ module Epilog
         ensure
           payload[:response] = response
           payload[:metrics] = epilog_metrics
+          payload[:context] = epilog_context
         end
       end
     end
@@ -38,6 +39,10 @@ module Epilog
         db_runtime: try(:db_runtime),
         view_runtime: view_runtime
       }
+    end
+
+    def epilog_context
+      {}
     end
   end
 end

--- a/spec/rails/action_controller_subscriber_spec.rb
+++ b/spec/rails/action_controller_subscriber_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe Epilog::Rails::ActionControllerSubscriber do
           db_runtime: 0,
           view_runtime: be_within(10).of(10),
           request_runtime: be_between(0, 20)
-        }
+        },
+        custom: 'custom context'
       )
     end
 

--- a/spec/rails_app/app/controllers/empty_controller.rb
+++ b/spec/rails_app/app/controllers/empty_controller.rb
@@ -5,4 +5,10 @@ class EmptyController < ActionController::Base
     params.permit(:id)
     render plain: ''
   end
+
+  def epilog_context
+    {
+      custom: 'custom context'
+    }
+  end
 end


### PR DESCRIPTION
Controllers may override the epilog_context method and return a hash to
add to all controller response log entries.