### PR TITLE
Add a filter using Rails filtered parameters

### DIFF
--- a/lib/epilog/filter.rb
+++ b/lib/epilog/filter.rb
@@ -2,3 +2,4 @@
 
 require 'epilog/filter/hash_key'
 require 'epilog/filter/blacklist'
+require 'epilog/filter/filter_parameters'

--- a/lib/epilog/filter/filter_parameters.rb
+++ b/lib/epilog/filter/filter_parameters.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Epilog
+  module Filter
+    class FilterParameters < Blacklist
+      private
+
+      def filter_parameters
+        return @filter_parameters if @filter_parameters
+
+        filtered = Hash[
+          ::Rails.application.config.filter_parameters.map do |p|
+            [p.to_s.downcase, true]
+          end
+        ]
+
+        @filter_parameters = filtered if ::Rails.initialized?
+        filtered
+      end
+
+      def key?(key)
+        filter_parameters.key?(key.to_s.downcase)
+      end
+    end
+  end
+end

--- a/spec/filter/filter_parameters_spec.rb
+++ b/spec/filter/filter_parameters_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Epilog::Filter::FilterParameters do
+  it 'filters parameters from Rails filter_parameters' do
+    filtered = described_class.new.call(
+      ok: 'good',
+      password: 'passw0rd1'
+    )
+
+    expect(filtered).to eq(
+      ok: 'good',
+      password: '[filtered String]'
+    )
+  end
+end


### PR DESCRIPTION
This filter uses the `filter_parameters` set by Rails to filter log
keys. It memoizes the keys, but only after Rails is initialized to make
sure that loggers initialized during boot don't mistakenly memoize an
empty array.