### PR TITLE
Fix removing Rails default params when filtered_parameters are set

### DIFF
--- a/lib/epilog/rails/action_controller_subscriber.rb
+++ b/lib/epilog/rails/action_controller_subscriber.rb
@@ -92,7 +92,7 @@ module Epilog
           headers: request.headers.to_h.keep_if do |key, _value|
             key =~ ActionDispatch::Http::Headers::HTTP_HEADER
           end,
-          params: request.filtered_parameters.except(*RAILS_PARAMS),
+          params: request.filtered_parameters.except(*rails_params),
           format: request.format.try(:ref),
           controller: event.payload[:controller],
           action: event.payload[:action]
@@ -146,6 +146,10 @@ module Epilog
 
           obj[key] = value.round(2) if value.is_a?(Numeric)
         end
+      end
+
+      def rails_params
+        @rails_params ||= RAILS_PARAMS + RAILS_PARAMS.map(&:to_s)
       end
     end
   end

--- a/spec/rails/action_controller_subscriber_spec.rb
+++ b/spec/rails/action_controller_subscriber_spec.rb
@@ -63,6 +63,16 @@ RSpec.describe Epilog::Rails::ActionControllerSubscriber do
         }
       )
     end
+
+    it 'removes default Rails params' do
+      get(:index, params(foo: 'bar', password: 'secret'))
+
+      expect(Rails.logger[0][3]).to match(hash_including(
+        request: hash_including(
+          params: { 'foo' => 'bar', 'password' => '[FILTERED]' }
+        )
+      ))
+    end
   end
 
   describe RedirectController, type: :controller do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ Combustion.initialize! :all do
   config.log_level = :debug
   config.action_controller.perform_caching = true
   config.cache_store = [:file_store, File.join(Rails.root, 'tmp/cache')]
+  config.filter_parameters = %w[password]
 
   if Rails::VERSION::MAJOR >= 5
     config.active_record.sqlite3.represent_boolean_as_integer = true


### PR DESCRIPTION
In Rails 4, when filtered_parameters were set, params were converted to
strings, which broke the Rails default param removal. Fix this by
removing both strings and symbols.