### PR TITLE
Downgrade ActionView logs to DEBUG

### DIFF
--- a/lib/epilog/rails/action_view_subscriber.rb
+++ b/lib/epilog/rails/action_view_subscriber.rb
@@ -4,15 +4,15 @@ module Epilog
   module Rails
     class ActionViewSubscriber < LogSubscriber
       def render_template(event)
-        info { hash(event, 'Rendered template') }
+        debug { hash(event, 'Rendered template') }
       end
 
       def render_partial(event)
-        info { hash(event, 'Rendered partial') }
+        debug { hash(event, 'Rendered partial') }
       end
 
       def render_collection(event)
-        info { hash(event, 'Rendered collection') }
+        debug { hash(event, 'Rendered collection') }
       end
 
       private

--- a/spec/rails/action_view_subscriber_spec.rb
+++ b/spec/rails/action_view_subscriber_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Epilog::Rails::ActionMailerSubscriber, type: :controller do
     view = ActionView::Base.new(ActionController::Base.view_paths, {})
     view.render(file: 'action_view/template.html.erb')
 
-    expect(Rails.logger[0][0]).to eq('INFO')
+    expect(Rails.logger[0][0]).to eq('DEBUG')
     expect(Rails.logger[0][3]).to match(
       message: 'Rendered template',
       layout: nil,
@@ -23,7 +23,7 @@ RSpec.describe Epilog::Rails::ActionMailerSubscriber, type: :controller do
     view = ActionView::Base.new(ActionController::Base.view_paths, {})
     view.render(file: 'action_view/template_w_partial.html.erb')
 
-    expect(Rails.logger[0][0]).to eq('INFO')
+    expect(Rails.logger[0][0]).to eq('DEBUG')
     expect(Rails.logger[0][3]).to match(
       message: 'Rendered partial',
       layout: nil,
@@ -38,7 +38,7 @@ RSpec.describe Epilog::Rails::ActionMailerSubscriber, type: :controller do
     view = ActionView::Base.new(ActionController::Base.view_paths, {})
     view.render(file: 'action_view/template_w_collection.html.erb')
 
-    expect(Rails.logger[0][0]).to eq('INFO')
+    expect(Rails.logger[0][0]).to eq('DEBUG')
     expect(Rails.logger[0][3]).to match(
       message: 'Rendered collection',
       layout: nil,


### PR DESCRIPTION
The ActionView logs were very noisy when rendering pages with large
numbers of templates and partials. These logs make more sense as DEBUG
logs.