### PR TITLE
Filter all request data using filtered_parameters

### DIFF
--- a/spec/rails/action_controller_subscriber_spec.rb
+++ b/spec/rails/action_controller_subscriber_spec.rb
@@ -69,7 +69,9 @@ RSpec.describe Epilog::Rails::ActionControllerSubscriber do
       get(:index, params(foo: 'bar', password: 'secret'))
 
       expect(Rails.logger[0][3]).to match(hash_including(
+        message: 'GET /empty started',
         request: hash_including(
+          path: '/empty',
           params: { 'foo' => 'bar', 'password' => '[FILTERED]' }
         )
       ))


### PR DESCRIPTION
- Remove query parameters from path and message
- Filter query, cookies, and headers