### PR TITLE
Add context to request log

### DIFF
--- a/lib/epilog/rails/action_controller_subscriber.rb
+++ b/lib/epilog/rails/action_controller_subscriber.rb
@@ -8,10 +8,10 @@ module Epilog
 
       def request_received(event)
         info do
-          {
+          event.payload[:context].merge(
             message: "#{request_string(event)} started",
             request: request_hash(event)
-          }
+          )
         end
       end
 

--- a/lib/epilog/rails/ext/action_controller.rb
+++ b/lib/epilog/rails/ext/action_controller.rb
@@ -10,7 +10,6 @@ module Epilog
         ensure
           payload[:response] = response
           payload[:metrics] = epilog_metrics
-          payload[:context] = epilog_context
         end
       end
     end
@@ -30,7 +29,8 @@ module Epilog
         request: request,
         response: response,
         controller: self.class.name,
-        action: action_name
+        action: action_name,
+        context: epilog_context
       }
     end
 

--- a/spec/rails/action_controller_subscriber_spec.rb
+++ b/spec/rails/action_controller_subscriber_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe Epilog::Rails::ActionControllerSubscriber do
           format: :html,
           controller: 'EmptyController',
           action: 'index'
-        }
+        },
+        custom: 'custom context'
       )
 
       expect(Rails.logger[2][0]).to eq('INFO')


### PR DESCRIPTION
The epilog_context was already added to responses, add it to requests as
well.