### PR TITLE
Add context support to Logger

### DIFF
--- a/lib/epilog.rb
+++ b/lib/epilog.rb
@@ -3,6 +3,7 @@
 require 'logger'
 
 require 'epilog/version'
+require 'epilog/context_logging'
 require 'epilog/logger'
 require 'epilog/mock_logger'
 require 'epilog/log_formatter'

--- a/lib/epilog/context_logging.rb
+++ b/lib/epilog/context_logging.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Epilog
+  module ContextLogger
+    def with_context(context)
+      push_context(context)
+      yield
+      pop_context
+    end
+
+    def push_context(context)
+      formatter.push_context(context)
+    end
+
+    def pop_context
+      formatter.pop_context
+    end
+  end
+
+  module ContextFormatter
+    def context
+      Thread.current[current_context_key] ||= begin
+        result = {}
+        context_stack.each { |frame| result.merge!(frame) }
+        result
+      end.freeze
+    end
+
+    def push_context(frame)
+      clear_context
+      context_stack.push(frame)
+    end
+
+    def pop_context
+      clear_context
+      context_stack.pop
+    end
+
+    private
+
+    def clear_context
+      Thread.current[current_context_key] = nil
+    end
+
+    def context_stack
+      Thread.current[stack_key] ||= []
+    end
+
+    def stack_key
+      @stack_key ||= "epilog_context_stack:#{object_id}"
+    end
+
+    def current_context_key
+      @current_context_key ||= "epilog_context_current:#{object_id}"
+    end
+  end
+end

--- a/lib/epilog/log_formatter.rb
+++ b/lib/epilog/log_formatter.rb
@@ -2,6 +2,8 @@
 
 module Epilog
   class Formatter
+    include ContextFormatter
+
     SEVERITY_MAP = {
       'FATAL' => 'ALERT',
       'WARN' => 'WARNING'
@@ -18,6 +20,7 @@ module Epilog
 
     def call(severity, time, progname, msg)
       log = base_log(severity, time, progname)
+      log.merge!(context)
       log.merge!(message(msg))
 
       if log[:exception].is_a?(Exception)

--- a/lib/epilog/logger.rb
+++ b/lib/epilog/logger.rb
@@ -2,6 +2,8 @@
 
 module Epilog
   class Logger < ::Logger
+    include ContextLogger
+
     def initialize(*args, **options)
       super
       self.formatter = Formatter.new

--- a/lib/epilog/mock_logger.rb
+++ b/lib/epilog/mock_logger.rb
@@ -2,8 +2,8 @@
 
 module Epilog
   class MockLogger < ::Logger
-    def initialize
-      super(nil)
+    def initialize(**options)
+      super(nil, **options)
       reset
     end
 
@@ -44,6 +44,21 @@ module Epilog
 
     def reset
       @logs = []
+      @context = []
+    end
+
+    def with_context(context)
+      push_context(context)
+      yield
+      pop_context
+    end
+
+    def push_context(context)
+      @context << context
+    end
+
+    def pop_context
+      @context.pop
     end
 
     private
@@ -53,7 +68,7 @@ module Epilog
     end
 
     def write(severity, time, prog, message)
-      @logs << [severity, time, prog, message]
+      @logs << [severity, time, prog, message, @context.dup]
     end
   end
 end

--- a/lib/epilog/rails/action_controller_subscriber.rb
+++ b/lib/epilog/rails/action_controller_subscriber.rb
@@ -7,24 +7,31 @@ module Epilog
       RAILS_PARAMS = %i[controller action format _method only_path].freeze
 
       def request_received(event)
+        push_context(
+          { request: short_request_hash(event) }
+          .merge(event.payload[:context])
+        )
+
         info do
-          event.payload[:context].merge(
+          {
             message: "#{request_string(event)} started",
             request: request_hash(event)
-          )
+          }
         end
       end
 
       def process_request(event)
         info do
-          event.payload[:context].merge(
+          {
             message: response_string(event),
             request: short_request_hash(event),
             response: response_hash(event),
             metrics: process_metrics(event.payload[:metrics]
               .merge(request_runtime: event.duration.round(2)))
-          )
+          }
         end
+
+        pop_context
       end
 
       def start_processing(*)

--- a/lib/epilog/rails/active_job_subscriber.rb
+++ b/lib/epilog/rails/active_job_subscriber.rb
@@ -12,6 +12,7 @@ module Epilog
       end
 
       def perform_start(event)
+        push_context(job: short_job_hash(event.payload[:job]))
         info { event_hash('Performing job', event) }
       end
 
@@ -23,6 +24,7 @@ module Epilog
             }
           )
         end
+        pop_context
       end
 
       private
@@ -42,6 +44,13 @@ module Epilog
           queue: job.queue_name,
           arguments: job.arguments,
           scheduled_at: job.scheduled_at ? format_time(job.scheduled_at) : nil
+        }
+      end
+
+      def short_job_hash(job)
+        {
+          class: job.class.name,
+          id: job.job_id
         }
       end
 

--- a/lib/epilog/rails/log_subscriber.rb
+++ b/lib/epilog/rails/log_subscriber.rb
@@ -9,6 +9,14 @@ module Epilog
         super()
         @logger = logger
       end
+
+      def push_context(context)
+        @logger.try(:push_context, context)
+      end
+
+      def pop_context
+        @logger.try(:pop_context)
+      end
     end
   end
 end

--- a/spec/context_logging_spec.rb
+++ b/spec/context_logging_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# rubocop:disable BlockLength
+RSpec.describe Epilog::ContextLogger do
+  let(:formatter_class) do
+    Class.new(::Logger::Formatter) do
+      def call(*)
+        "#{JSON.dump(@context)}\n"
+      end
+
+      def push_context(context)
+        @context = context
+      end
+
+      def pop_context
+        @context = nil
+      end
+    end
+  end
+
+  let(:logger_class) do
+    Class.new(::Logger) do
+      include Epilog::ContextLogger
+    end
+  end
+
+  subject do
+    logger = logger_class.new(output)
+    logger.formatter = formatter
+    logger
+  end
+  let(:formatter) { formatter_class.new }
+  let(:output) { StringIO.new }
+
+  it 'temporarily adds context to the formatter' do
+    subject.with_context(user_id: 123) do
+      subject.info('hi')
+    end
+
+    subject.info('done')
+
+    output.rewind
+    expect(output.read).to eq(
+      <<~LOG
+        {"user_id":123}
+        null
+      LOG
+    )
+  end
+end
+
+RSpec.describe Epilog::ContextFormatter do
+  let(:formatter_class) do
+    Class.new(::Logger::Formatter) do
+      include Epilog::ContextFormatter
+
+      def call(*)
+        context
+      end
+    end
+  end
+
+  subject { formatter_class.new }
+
+  it 'pushes context on the stack' do
+    subject.push_context(user_id: 123)
+    expect(subject.call).to eq(user_id: 123)
+  end
+
+  it 'merges multiple context frames' do
+    subject.push_context(user_id: 123)
+    subject.push_context(admin_id: 99)
+    expect(subject.call).to eq(user_id: 123, admin_id: 99)
+    subject.pop_context
+    expect(subject.call).to eq(user_id: 123)
+  end
+
+  it 'starts with empty context' do
+    expect(subject.call).to eq({})
+  end
+
+  it 'has empty context if all frames are popped' do
+    subject.push_context(user_id: 123)
+    subject.push_context(admin_id: 99)
+    subject.pop_context
+    subject.pop_context
+    expect(subject.call).to eq({})
+  end
+end
+# rubocop:enable BlockLength

--- a/spec/rails_app/app/controllers/empty_controller.rb
+++ b/spec/rails_app/app/controllers/empty_controller.rb
@@ -3,6 +3,7 @@
 class EmptyController < ActionController::Base
   def index
     params.permit(:id)
+    Rails.logger.info('test log')
     render plain: ''
   end
 

--- a/spec/rails_app/app/controllers/error_controller.rb
+++ b/spec/rails_app/app/controllers/error_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ErrorController < ActionController::Base
+  def index
+    raise 'Something bad happened'
+  end
+end

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
   resources 'file'
   resources 'halt'
   resources 'fragment'
+  resources 'error'
 end


### PR DESCRIPTION
- Add ContextFormatter to track a thread-local context
- Add context support to Formatter
- Add ContextLogger to allow setting context from a Logger instance
- Track context in ActionControllerSubscriber and ActiveJobSubscriber