### PR TITLE
Allow ActiveJobSubscriber spec to run longer

### DIFF
--- a/spec/rails/active_job_subscriber_spec.rb
+++ b/spec/rails/active_job_subscriber_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Epilog::Rails::ActiveJobSubscriber do
       },
       adapter: 'ActiveJob::QueueAdapters::InlineAdapter',
       metrics: {
-        job_runtime: be_between(0, 20)
+        job_runtime: be_between(0, 100)
       }
     )
     expect(Rails.logger[2][4]).to match([context])


### PR DESCRIPTION
The job_runtime test was sometimes failing because it ran long