### PR TITLE
Add options to enable/disable start and end logs

### DIFF
--- a/lib/epilog/rails/active_job_subscriber.rb
+++ b/lib/epilog/rails/active_job_subscriber.rb
@@ -13,6 +13,8 @@ module Epilog
 
       def perform_start(event)
         push_context(job: short_job_hash(event.payload[:job]))
+        return unless config.double_job_logs
+
         info { event_hash('Performing job', event) }
       end
 

--- a/lib/epilog/rails/log_subscriber.rb
+++ b/lib/epilog/rails/log_subscriber.rb
@@ -17,6 +17,10 @@ module Epilog
       def pop_context
         @logger.try(:pop_context)
       end
+
+      def config
+        ::Rails.application.config.epilog
+      end
     end
   end
 end

--- a/lib/epilog/rails/railtie.rb
+++ b/lib/epilog/rails/railtie.rb
@@ -20,6 +20,8 @@ module Epilog
       ].freeze
 
       config.epilog = ActiveSupport::OrderedOptions.new
+      config.epilog.double_request_logs = true
+      config.epilog.double_job_logs = true
       config.epilog.subscriptions = %i[
         action_controller
         action_mailer

--- a/spec/rails/action_controller_subscriber_spec.rb
+++ b/spec/rails/action_controller_subscriber_spec.rb
@@ -86,6 +86,21 @@ RSpec.describe Epilog::Rails::ActionControllerSubscriber do
         )
       ))
     end
+
+    context 'with double_request_logs = false' do
+      around do |example|
+        Rails.application.config.epilog.double_request_logs = false
+        example.run
+        Rails.application.config.epilog.double_request_logs = true
+      end
+
+      it 'skips start log' do
+        get(:index)
+        expect(Rails.logger[2][3]).to match(hash_including(
+          message: 'GET /empty > 200 OK'
+        ))
+      end
+    end
   end
 
   describe RedirectController, type: :controller do

--- a/spec/rails/active_job_subscriber_spec.rb
+++ b/spec/rails/active_job_subscriber_spec.rb
@@ -76,6 +76,21 @@ RSpec.describe Epilog::Rails::ActiveJobSubscriber do
     )
   end
 
+  context 'with double_job_logs = false' do
+    around do |example|
+      Rails.application.config.epilog.double_job_logs = false
+      example.run
+      Rails.application.config.epilog.double_job_logs = true
+    end
+
+    it 'skips start log' do
+      TestJob.perform_later
+      expect(Rails.logger[1][3]).to match(hash_including(
+        message: 'Performed job'
+      ))
+    end
+  end
+
   describe TestErrorJob do
     it 'resets context after error' do
       expect { TestErrorJob.perform_later }


### PR DESCRIPTION
ActionController and ActiveJob log subscribers send logs for both
starting and ending a task. This causes double entries for those tasks
which increases log volume. Some users may want to reduce their log
volume by consolidating those logs into one.

Added options double_job_logs and double_request_logs to give users that
choice. By default, they are set to true, which maintains backwards
compatibility.