### PR TITLE
Use ensure to pop logging context

### DIFF
--- a/lib/epilog/context_logging.rb
+++ b/lib/epilog/context_logging.rb
@@ -5,6 +5,7 @@ module Epilog
     def with_context(context)
       push_context(context)
       yield
+    ensure
       pop_context
     end
 


### PR DESCRIPTION
If an exception was thrown inside with_context, it could fail to pop the
context off the stack.