### PR TITLE
Support Rails 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 /spec/rails_app/log/
 /spec/rails_app/db/test.sqlite
+/.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
 env:
   matrix:
-    - RAILS_VERSION=4.2
     - RAILS_VERSION=5.2
+    - RAILS_VERSION=6.0
+    - RAILS_VERSION=6.1
   global:
     - COVERAGE=1
     - secure: 'nm0AJBULqunzS//h26lblqWHV4Kl0Ij9OPVHMI761TNeFFjP2+KKUVh4qYEKrdUDp7pk9Wa4CdAB9EFLYTJMwyK8RlSkdMLaHGT9xdOqbycBS6vkW2symvdu58SSdsNmnnFV4ebOwEmEcDhAh8SyT0ZkUVhyzGntdzOOZmULi57kOwm8QGrrr4/4xaTmDleZlTDS404nD28wJctaBT8Xa33inaYYrHLKz4xbvFFtptrPb+Arav9enljqiqOu4XjXCIP2eOSP7PHkDPuRn0JKDFT3zKmj0MIUbYkoheQL6R3tMF9zx5gm4GKbd7iunuIsjbFweiveZwZhfNGDPCICuw76UWZCrN4PpomA7XDNjbs0JVRJvnBxLZk5X3w3Sacb4zBTd+U8WH7uAb9qdD7m4xUswox4tPZDPXYObw2PDqtLlsSRn3WDKsnG0/Tt0D+kFsx43MbrvspdOzjarJsIXzU9aJqfE97nM4ZrNcktsW4PrqGflhcDVTKg+kLQj4bO0csR1W/JhGHN0JsVNUmNFN9QqpuRxxI/AmnPBtKR29DDy3BUv1b/kCZbsqq4+wbgCKDJng5VBgpG4VekOiTT2xmlwoxNK4IUAISbu7G/eyCcp33jb+27QE74a13xQsMLvh/wjh1sFEfzJvQzXFL+gjkVP4Z/+uSbc2+8/p+FKm8='
@@ -28,7 +30,7 @@ after_script:
 jobs:
   include:
     - stage: release
-      rvm: 2.3
+      rvm: 2.6
       script: skip
       deploy:
         provider: rubygems

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,9 @@ gemspec
 
 group :test do
   gem 'rails', "~> #{ENV.fetch('RAILS_VERSION', '5.2')}"
+  if ENV.fetch('RAILS_VERSION', '5.2').to_f >= 5
+    gem 'sqlite3', '~> 1.4'
+  else
+    gem 'sqlite3', '= 1.3.10' # rubocop:disable Bundler/DuplicatedGem
+  end
 end

--- a/epilog.gemspec
+++ b/epilog.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 1.12'
   spec.add_development_dependency 'byebug', '~> 11.0'
-  spec.add_development_dependency 'combustion', '~> 1.1.0'
+  spec.add_development_dependency 'combustion', '~> 1.3'
   spec.add_development_dependency 'irb'
   spec.add_development_dependency 'rails', '>= 4.2', '< 7'
   spec.add_development_dependency 'rake', '~> 13.0'
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails', '~> 3.8.1'
   spec.add_development_dependency 'rubocop', '0.75'
   spec.add_development_dependency 'simplecov', '~> 0.17'
-  spec.add_development_dependency 'sqlite3', '~> 1.3', '< 1.4'
+  spec.add_development_dependency 'sqlite3', '~> 1.3', '< 1.5'
   spec.add_development_dependency 'yard', '~> 0.9.11'
 end

--- a/epilog.gemspec
+++ b/epilog.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'byebug', '~> 11.0'
   spec.add_development_dependency 'combustion', '~> 1.1.0'
   spec.add_development_dependency 'irb'
-  spec.add_development_dependency 'rails', '>= 4.2', '< 6'
+  spec.add_development_dependency 'rails', '>= 4.2', '< 7'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'redcarpet', '~> 3.5'
   spec.add_development_dependency 'rspec', '~> 3.4'

--- a/lib/epilog/rails/action_mailer_subscriber.rb
+++ b/lib/epilog/rails/action_mailer_subscriber.rb
@@ -13,6 +13,8 @@ module Epilog
         end
       end
 
+      # Method `receive` removed in Rails 6.1
+      # https://github.com/rails/rails/commit/d5fa9569a0d401893d54ee47fe43fd87b6155fb7
       def receive(event)
         info do
           hash(

--- a/lib/epilog/rails/epilog_ext.rb
+++ b/lib/epilog/rails/epilog_ext.rb
@@ -8,4 +8,9 @@ module Epilog
   end
 end
 
-Epilog::Logger.send(:include, defined?(ActiveSupport::LoggerSilence) ? ActiveSupport::LoggerSilence : ::LoggerSilence)
+logger_silencer = if Rails::VERSION::MAJOR >= 6
+  ActiveSupport::LoggerSilence
+else
+  ::LoggerSilence
+end
+Epilog::Logger.send(:include, logger_silencer)

--- a/lib/epilog/rails/epilog_ext.rb
+++ b/lib/epilog/rails/epilog_ext.rb
@@ -2,10 +2,10 @@
 
 module Epilog
   class Logger
-    include LoggerSilence
-
     def silencer
       false
     end
   end
 end
+
+Epilog::Logger.send(:include, defined?(ActiveSupport::LoggerSilence) ? ActiveSupport::LoggerSilence : ::LoggerSilence)

--- a/lib/epilog/rails/ext/action_controller.rb
+++ b/lib/epilog/rails/ext/action_controller.rb
@@ -47,7 +47,9 @@ module Epilog
   end
 end
 
-ActionController::Base.prepend(Epilog::ActionControllerExt)
-if defined? ActionController::API
-  ActionController::API.prepend(Epilog::ActionControllerExt)
+ActiveSupport.on_load(:action_controller_base) do
+  ActionController::Base.prepend(Epilog::ActionControllerExt)
+  if defined? ActionController::API
+    ActionController::API.prepend(Epilog::ActionControllerExt)
+  end
 end

--- a/lib/epilog/rails/ext/action_controller.rb
+++ b/lib/epilog/rails/ext/action_controller.rb
@@ -47,9 +47,17 @@ module Epilog
   end
 end
 
-ActiveSupport.on_load(:action_controller_base) do
+def prepend_controller_ext
   ActionController::Base.prepend(Epilog::ActionControllerExt)
-  if defined? ActionController::API
-    ActionController::API.prepend(Epilog::ActionControllerExt)
+  return unless defined? ActionController::API
+
+  ActionController::API.prepend(Epilog::ActionControllerExt)
+end
+
+if ::Rails::VERSION::MAJOR < 5
+  prepend_controller_ext
+else
+  ActiveSupport.on_load(:action_controller_base) do
+    prepend_controller_ext
   end
 end

--- a/lib/epilog/version.rb
+++ b/lib/epilog/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Epilog
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end

--- a/spec/rails/action_mailer_subscriber_spec.rb
+++ b/spec/rails/action_mailer_subscriber_spec.rb
@@ -28,17 +28,22 @@ RSpec.describe Epilog::Rails::ActionMailerSubscriber, type: :controller do
     )
   end
 
-  it 'logs receiving mail' do
-    TestMailer.receive(Mail.new(body: 'test mail').to_s)
+  # Method `receive` removed in Rails 6.1
+  # https://github.com/rails/rails/commit/d5fa9569a0d401893d54ee47fe43fd87b6155fb7
+  if Gem::Version.new(Rails::VERSION::STRING) < Gem::Version.new('6.1.0')
+    it 'logs receiving mail' do
+      TestMailer.receive(Mail.new(body: 'test mail').to_s)
 
-    expect(Rails.logger[0][0]).to eq('INFO')
-    expect(Rails.logger[0][3]).to match(
-      message: 'Received mail',
-      body: include('test mail'),
-      metrics: {
-        duration: be_between(0, 20)
-      }
-    )
+      expect(Rails.logger[0][0]).to eq('INFO')
+      expect(Rails.logger[0][3])
+        .to match(
+          message: 'Received mail',
+          body: include('test mail'),
+          metrics: {
+            duration: be_between(0, 20)
+          }
+        )
+    end
   end
 end
 # rubocop:enable BlockLength

--- a/spec/rails/action_view_subscriber_spec.rb
+++ b/spec/rails/action_view_subscriber_spec.rb
@@ -1,12 +1,22 @@
 # frozen_string_literal: true
 
 # rubocop:disable BlockLength
-RSpec.describe Epilog::Rails::ActionMailerSubscriber, type: :controller do
+RSpec.describe Epilog::Rails::ActionViewSubscriber, type: :controller do
   render_views
 
+  let(:lookup_context) do
+    ActionView::LookupContext.new(ActionController::Base.view_paths)
+  end
+  let(:view) { ActionViewBasePlus.new(lookup_context, {}, EmptyController.new) }
+
+  class ActionViewBasePlus < ActionView::Base
+    def compiled_method_container
+      self.class
+    end
+  end
+
   it 'logs rendering a template' do
-    view = ActionView::Base.new(ActionController::Base.view_paths, {})
-    view.render(file: 'action_view/template.html.erb')
+    view.render(template: 'action_view/template.html.erb')
 
     expect(Rails.logger[0][0]).to eq('DEBUG')
     expect(Rails.logger[0][3]).to match(
@@ -20,8 +30,7 @@ RSpec.describe Epilog::Rails::ActionMailerSubscriber, type: :controller do
   end
 
   it 'logs rendering a partial' do
-    view = ActionView::Base.new(ActionController::Base.view_paths, {})
-    view.render(file: 'action_view/template_w_partial.html.erb')
+    view.render(template: 'action_view/template_w_partial.html.erb')
 
     expect(Rails.logger[0][0]).to eq('DEBUG')
     expect(Rails.logger[0][3]).to match(
@@ -35,8 +44,7 @@ RSpec.describe Epilog::Rails::ActionMailerSubscriber, type: :controller do
   end
 
   it 'logs rendering a collection' do
-    view = ActionView::Base.new(ActionController::Base.view_paths, {})
-    view.render(file: 'action_view/template_w_collection.html.erb')
+    view.render(template: 'action_view/template_w_collection.html.erb')
 
     expect(Rails.logger[0][0]).to eq('DEBUG')
     expect(Rails.logger[0][3]).to match(

--- a/spec/rails/active_job_subscriber_spec.rb
+++ b/spec/rails/active_job_subscriber_spec.rb
@@ -104,7 +104,8 @@ RSpec.describe Epilog::Rails::ActiveJobSubscriber do
       job_context = [job: hash_including(class: 'TestErrorJob')]
       expect(Rails.logger[0][4]).to match(job_context)
       expect(Rails.logger[2][4]).to eq([])
-      expect(Rails.logger[3][4]).to match(job_context)
+      log_line = Rails::VERSION::MAJOR >= 6 ? 4 : 3
+      expect(Rails.logger[log_line][4]).to match(job_context)
     end
   end
 end

--- a/spec/rails/active_record_subscriber_spec.rb
+++ b/spec/rails/active_record_subscriber_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Epilog::Rails::ActiveRecordSubscriber do
       binds << { type: nil, name: 'LIMIT', value: 1 }
     end
 
+    query.gsub!('  ', ' ') if Rails::VERSION::MAJOR >= 6
+
     User.find_by(id: 1)
     expect(Rails.logger[0][0]).to eq('DEBUG')
     expect(Rails.logger[0][3]).to match(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ Combustion.initialize! :all do
   config.cache_store = [:file_store, File.join(Rails.root, 'tmp/cache')]
   config.filter_parameters = %w[password]
 
-  if Rails::VERSION::MAJOR >= 5
+  if Rails::VERSION::MAJOR == 5
     config.active_record.sqlite3.represent_boolean_as_integer = true
   end
 end
@@ -34,6 +34,31 @@ $stdout = @orig_stdout
 
 require 'epilog'
 require 'rspec/rails'
+
+# a workaround to avoid MonitorMixin double-initialize error
+# https://github.com/rails/rails/issues/34790#issuecomment-681034561
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6.0')
+  if Gem::Version.new(::Rails.version) < Gem::Version.new('5.0.0')
+    # rubocop:disable Style/ClassAndModuleChildren
+    class ActionController::TestResponse < ActionDispatch::TestResponse
+      def recycle!
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+          @mon_data = nil
+          @mon_data_owner_object_id = nil
+        else
+          @mon_mutex = nil
+          @mon_mutex_owner_object_id = nil
+        end
+        initialize
+      end
+    end
+    # rubocop:enable Style/ClassAndModuleChildren
+  else
+    puts(
+      'Monkeypatch for ActionController::TestResponse is no longer needed'
+    )
+  end
+end
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
There are several changes added to support Rails 6:
1. Update to gemspec file
2. Use correct `LoggerSilence` class
3. Fix `ActionController::Base` prepending