### PR TITLE
Add support for Rails 8+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
           - ruby: '3.4'
             rails: '7.2'
             bundler: 'default'
+          - ruby: '3.4'
+            rails: '8.0'
+            bundler: 'default'
+          - ruby: '3.4'
+            rails: '8.1'
+            bundler: 'default'
     env:
       RAILS_VERSION: ${{ matrix.rails }}
 
@@ -33,14 +39,14 @@ jobs:
           bundler: ${{ matrix.bundler }}
           bundler-cache: true
       - run: bundle exec rubocop
-        if: matrix.rails == '7.1'
+        if: matrix.rails == '8.0'
       - run: bundle exec rspec --format doc
       - uses: codecov/codecov-action@v3
-        if: matrix.rails == '7.1'
+        if: matrix.rails == '8.0'
         with:
           files: coverage/coverage.xml
       - run: bin/yardoc --fail-on-warning
-        if: matrix.rails == '7.1'
+        if: matrix.rails == '8.0'
       - run: bin/check-version
 
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,19 @@ jobs:
       matrix:
         include:
           - ruby: '3.3' # v1.x sqlite3 requires Ruby 3.3
-            rails: '7.0'
+            rails: '7.0.0'
             bundler: 'default'
           - ruby: '3.4'
-            rails: '7.1'
+            rails: '7.1.0'
             bundler: 'default'
           - ruby: '3.4'
-            rails: '7.2'
+            rails: '7.2.0'
             bundler: 'default'
           - ruby: '3.4'
-            rails: '8.0'
+            rails: '8.0.0'
             bundler: 'default'
           - ruby: '3.4'
-            rails: '8.1'
+            rails: '8.1.0'
             bundler: 'default'
     env:
       RAILS_VERSION: ${{ matrix.rails }}
@@ -39,14 +39,14 @@ jobs:
           bundler: ${{ matrix.bundler }}
           bundler-cache: true
       - run: bundle exec rubocop
-        if: matrix.rails == '8.0'
+        if: matrix.rails == '8.0.0'
       - run: bundle exec rspec --format doc
       - uses: codecov/codecov-action@v3
-        if: matrix.rails == '8.0'
+        if: matrix.rails == '8.0.0'
         with:
           files: coverage/coverage.xml
       - run: bin/yardoc --fail-on-warning
-        if: matrix.rails == '8.0'
+        if: matrix.rails == '8.0.0'
       - run: bin/check-version
 
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.10.0
+
+- Add support for Rails 8.0 and Rails 8.1
+- Fix ActiveRecord subscriber for Rails 8.1 RuntimeRegistry API change
+- Fix CI version pinning to use three-segment version constraints
+
 ## 0.9.2
 
 - Fix double log issue in Rails 7.1+

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 not_jruby = %i[ruby mingw x64_mingw].freeze
-rails_version = Gem::Version.new(ENV.fetch('RAILS_VERSION', '7.1.0'))
+rails_version = Gem::Version.new(ENV.fetch('RAILS_VERSION', '8.0.0'))
 
 gem 'byebug', platforms: not_jruby
 gem 'rails', "~> #{rails_version}"

--- a/lib/epilog/rails/active_record_subscriber.rb
+++ b/lib/epilog/rails/active_record_subscriber.rb
@@ -6,7 +6,7 @@ module Epilog
       IGNORE_PAYLOAD_NAMES = %w[SCHEMA EXPLAIN].freeze
 
       def sql(event)
-        ActiveRecord::RuntimeRegistry.sql_runtime = (ActiveRecord::RuntimeRegistry.sql_runtime || 0) + event.duration
+        record_sql_runtime(event.duration)
 
         return unless logger.debug?
 
@@ -22,6 +22,17 @@ module Epilog
       end
 
       private
+
+      # Rails 8.1 moved sql_runtime from a module-level accessor to
+      # ActiveRecord::RuntimeRegistry.stats.sql_runtime (a Stats object).
+      # See https://github.com/rails/rails/commit/7d12071e9fe94bd5c01a488ef61718fe88de65b4
+      def record_sql_runtime(duration)
+        if ActiveRecord::RuntimeRegistry.respond_to?(:sql_runtime=)
+          ActiveRecord::RuntimeRegistry.sql_runtime = (ActiveRecord::RuntimeRegistry.sql_runtime || 0) + duration
+        else
+          ActiveRecord::RuntimeRegistry.stats.sql_runtime += duration
+        end
+      end
 
       def metrics(event)
         {

--- a/lib/epilog/version.rb
+++ b/lib/epilog/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Epilog
-  VERSION = '0.9.2'
+  VERSION = '0.10.0'
 
   def self.version
     Gem::Version.new(VERSION)

--- a/spec/rails_app/app/controllers/redirect_controller.rb
+++ b/spec/rails_app/app/controllers/redirect_controller.rb
@@ -2,6 +2,6 @@
 
 class RedirectController < ActionController::Base
   def index
-    redirect_to 'https://www.google.com'
+    redirect_to 'https://www.google.com', allow_other_host: true
   end
 end


### PR DESCRIPTION
## Summary

- Add Rails 8.0 and 8.1 to the CI matrix
- Fix `ActiveRecordSubscriber` for Rails 8.1, which [moved `sql_runtime`](https://github.com/rails/rails/commit/7d12071e9fe94bd5c01a488ef61718fe88de65b4) from a module-level accessor on `ActiveRecord::RuntimeRegistry` to a nested `Stats` object (`RuntimeRegistry.stats.sql_runtime`)
- Fix redirect spec for Rails 8.1, which [now logs a WARN](https://github.com/rails/rails/commit/3f2a756b78a546b125a09a4d43a88a9fba51660c) for external redirects without `allow_other_host: true`
- Fix CI version pinning: use three-segment versions (`7.0.0` instead of `7.0`) so that `~>` constraints pin to the intended minor version
- Bump version to 0.10.0